### PR TITLE
Add https support for non-auth enabled MM route.

### DIFF
--- a/odh-model-controller/controllers/inferenceservice_route.go
+++ b/odh-model-controller/controllers/inferenceservice_route.go
@@ -73,6 +73,11 @@ func NewInferenceServiceRoute(inferenceservice *inferenceservicev1.InferenceServ
 			Termination:                   routev1.TLSTerminationReencrypt,
 			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
 		}
+	} else {
+		finalRoute.Spec.TLS = &routev1.TLSConfig{
+			Termination:                   routev1.TLSTerminationEdge,
+			InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyRedirect,
+		}
 	}
 
 	return finalRoute


### PR DESCRIPTION
Cherry picked commit for 1.20, see https://github.com/red-hat-data-services/modelmesh-serving/pull/4