### PR TITLE
create etcd secrets inside initContainer

### DIFF
--- a/manifests/opendatahub/dependencies/quickstart.yaml
+++ b/manifests/opendatahub/dependencies/quickstart.yaml
@@ -47,6 +47,35 @@ spec:
           configMap:
             name: etcd-scripts
             defaultMode: 0554
+      initContainers: 
+        - name: etcd-secret-creator
+          image: quay.io/openshift/origin-cli
+          command: ["/bin/bash", "-c", "--"]
+          args:
+            - |
+              etcdpasswordexists=$(oc get secrets -o name | grep etcd-passwords || echo "false")
+              modelservingetcdexists=$(oc get secrets -o name | grep model-serving-etcd || echo "false")
+              
+              if [[ $etcdpasswordexists == "false" && $modelservingetcdexists == "false" ]]; then
+                echo "creating etcdpasswords and model-serving-etcd secrets"
+                ETC_ROOT_PSW=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 32 | head -n 1)
+                oc create secret generic etcd-passwords --type=string --from-literal=root=$ETC_ROOT_PSW
+                oc create secret generic model-serving-etcd --type=string --from-literal=etcd_connection="{\"endpoints\": \"http://etcd:2379\",\"root_prefix\": \"modelmesh-serving\",\"userid\": \"root\",\"password\": \"$ETC_ROOT_PSW\"}"
+                exit 0
+              elif [[ $etcdpasswordexists != "false" && $modelservingetcdexists == "false" ]]; then
+                echo "etcdpasswords exists, creating model-serving-etcd secret"
+                ETC_ROOT_PSW=$(oc get secrets/etcd-passwords --template={{.data.root}} | base64 -d)
+                oc create secret generic model-serving-etcd --type=string --from-literal=etcd_connection="{\"endpoints\": \"http://etcd:2379\",\"root_prefix\": \"modelmesh-serving\",\"userid\": \"root\",\"password\": \"$ETC_ROOT_PSW\"}"
+                exit 0
+              elif [[ $etcdpasswordexists == "false" && $modelservingetcdexists != "false" ]]; then
+                echo "model-serving-etcd exists, creating etcdpasswords secret"
+                ETC_ROOT_PSW=$(oc get secrets/model-serving-etcd --template={{.data.etcd_connection}} | base64 -d | grep -o '"password": *"[^"]*"' | grep -o '"[^"]*"$' | grep -oP '"\K[^"\047]+(?=["\047])') 
+                oc create secret generic etcd-passwords --type=string --from-literal=root=$ETC_ROOT_PSW
+                exit 0
+              else 
+                echo "secrets etcdpasswords and model-serving-etcd exist, doing nothing"
+                exit 0
+              fi
       containers:
         - command:
             - etcd
@@ -104,3 +133,40 @@ spec:
                   - /bin/sh
                   - -c
                   - /home/scripts/enable_auth.sh ${ROOT_PASSWORD}
+      serviceAccountName: etcd-serviceaccount
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: etcd-serviceaccount
+  namespace: $(monitoring-namespace) 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: etcd-role
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-role
+subjects:
+  - kind: ServiceAccount
+    name: etcd-serviceaccount

--- a/quickstart/quickstart.sh
+++ b/quickstart/quickstart.sh
@@ -30,12 +30,7 @@ MODELMESH_PROJECT=${1:-"opendatahub"}
 INFERENCE_SERVICE_PROJECT=${2:-"mesh-test"}
 
 oc new-project $MODELMESH_PROJECT
-ETC_ROOT_PSW=$(openssl rand -hex 32)
-sed -i "s/<etcd_password>/${ETC_ROOT_PSW}/g" etcd-secrets.yaml
-sed -i "s/<etcd_password>/${ETC_ROOT_PSW}/g" etcd-users.yaml
 sed -i "s/<namespace>/${MODELMESH_PROJECT}/g" ../manifests/kfdef.yaml
-oc apply -f etcd-secrets.yaml -n $MODELMESH_PROJECT
-oc apply -f etcd-users.yaml -n $MODELMESH_PROJECT
 oc apply -f ../manifests/kfdef.yaml -n $MODELMESH_PROJECT
 
 oc new-project $INFERENCE_SERVICE_PROJECT


### PR DESCRIPTION
## Description : 

This PR, along with [this](https://github.com/red-hat-data-services/odh-deployer/pull/309) and [this](https://github.com/red-hat-data-services/modelmesh-serving/pull/11) are meant to be tested together. Together, they address [RHODS-7487](https://issues.redhat.com/browse/RHODS-7487). etcd secret creation is moved from odh deployer to etcd initContainer. 

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] For commits that came from upstream, `[UPSTREAM]` has been prepended to the commit message
- [x] JIRA link(s): https://issues.redhat.com/browse/RHODS-7487
- [x] The Jira story is acked
- [x] An entry has been added to the latest build document in [Build Announcements Folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL).
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious)

## Testing Instructions
- Install `quay.io/vedantm/rhods-operator-live-catalog:1.24.0-etcd`  
- Look at odh-deployer logs
  - search logs for `secret/etcd-passwords` and `secret/model-serving-etcd created`. result should be empty
  - in `redhat-ods-applications` look for the etcd pod
  - etcd Pod should have an initContainer with logs for 2 secrets created
