### PR TITLE
Change oc cli image from quay to registry.redhat for downstream

### DIFF
--- a/manifests/opendatahub/dependencies/quickstart.yaml
+++ b/manifests/opendatahub/dependencies/quickstart.yaml
@@ -49,7 +49,7 @@ spec:
             defaultMode: 0554
       initContainers: 
         - name: etcd-secret-creator
-          image: quay.io/openshift/origin-cli
+          image: registry.redhat.io/openshift4/ose-cli@sha256:25fef269ac6e7491cb8340119a9b473acbeb53bc6970ad029fdaae59c3d0ca61
           command: ["/bin/bash", "-c", "--"]
           args:
             - |


### PR DESCRIPTION
#### Motivation
Use internal image for RHODS

#### Modifications
Change quay oc cli image to registry.redhat image

#### Result
No change in functionality