### PR TITLE
Oauth proxy image tag

### DIFF
--- a/config/internal/base/deployment.yaml.tmpl
+++ b/config/internal/base/deployment.yaml.tmpl
@@ -138,7 +138,7 @@ spec:
             - '--openshift-delegate-urls={"/": {"namespace": "{{.AuthNamespace}}", "resource": "services", "verb": "get"}}'
             - '--openshift-sar={"namespace": "{{.AuthNamespace}}", "resource": "services", "verb": "get"}'
             - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-          image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
+          image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
           ports:
             - containerPort: 8443
               name: https

--- a/config/internal/base/deployment.yaml.tmpl
+++ b/config/internal/base/deployment.yaml.tmpl
@@ -63,8 +63,6 @@ spec:
           env:
             - name: MM_SERVICE_NAME
               value: {{.ServiceName}}
-            - name: MM_PAYLOAD_PROCESSORS
-              value: {{.PayloadProcessors}}
             # External gRPC port of the service, should match ports.containerPort
             - name: MM_SVC_GRPC_PORT
               value: "{{.Port}}"

--- a/controllers/testdata/servingruntime_controller.golden
+++ b/controllers/testdata/servingruntime_controller.golden
@@ -102,7 +102,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -413,7 +413,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -694,7 +694,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1049,7 +1049,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1353,7 +1353,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1649,7 +1649,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1950,7 +1950,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -2245,7 +2245,7 @@ spec:
         - '--openshift-sar={"namespace": "default", "resource": "services", "verb":
           "get"}'
         - --skip-auth-regex='(^/metrics|^/apis/v1beta1/healthz)'
-        image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.8
+        image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4bef31eb993feb6f1096b51b4876c65a6fb1f4401fee97fa4f4542b6b7c9bc46
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
#### Motivation
OAuth Proxy Image must use sha256 for disconnected installation. This is a regression bug.

#### Modifications
Update oauth-proxy image tag to sha256

#### Result
model serving runtime can pull the oauth proxy image from private registry without internet.

#### Test
Live Builder : quay.io/jooholee/rhods-operator-live-catalog:1.25.0-release-test 

#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [V] Unit tests pass locally
- [V] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 

