### PR TITLE
reverting crd changes done for kserve release-v0.15

### DIFF
--- a/config/crd/bases/serving.kserve.io_inferenceservices.yaml
+++ b/config/crd/bases/serving.kserve.io_inferenceservices.yaml
@@ -936,8 +936,6 @@ spec:
                                 properties:
                                   name:
                                     type: string
-                                  request:
-                                    type: string
                                 required:
                                   - name
                                 type: object
@@ -1188,157 +1186,6 @@ spec:
                           x-kubernetes-list-type: map
                         workingDir:
                           type: string
-                      type: object
-                    autoScaling:
-                      properties:
-                        metrics:
-                          items:
-                            properties:
-                              external:
-                                properties:
-                                  authenticationRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    required:
-                                      - name
-                                    type: object
-                                  metric:
-                                    properties:
-                                      authModes:
-                                        type: string
-                                      backend:
-                                        enum:
-                                          - prometheus
-                                          - graphite
-                                        type: string
-                                      namespace:
-                                        type: string
-                                      query:
-                                        type: string
-                                      serverAddress:
-                                        type: string
-                                    type: object
-                                  target:
-                                    properties:
-                                      averageUtilization:
-                                        format: int32
-                                        type: integer
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type:
-                                        enum:
-                                          - Utilization
-                                          - Value
-                                          - AverageValue
-                                        type: string
-                                      value:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    type: object
-                                required:
-                                  - metric
-                                  - target
-                                type: object
-                              podmetric:
-                                properties:
-                                  metric:
-                                    properties:
-                                      backend:
-                                        enum:
-                                          - opentelemetry
-                                        type: string
-                                      metricNames:
-                                        items:
-                                          type: string
-                                        type: array
-                                      operationOverTime:
-                                        type: string
-                                      query:
-                                        type: string
-                                      serverAddress:
-                                        type: string
-                                    type: object
-                                  target:
-                                    properties:
-                                      averageUtilization:
-                                        format: int32
-                                        type: integer
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type:
-                                        enum:
-                                          - Utilization
-                                          - Value
-                                          - AverageValue
-                                        type: string
-                                      value:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    type: object
-                                required:
-                                  - metric
-                                  - target
-                                type: object
-                              resource:
-                                properties:
-                                  name:
-                                    enum:
-                                      - cpu
-                                      - memory
-                                    type: string
-                                  target:
-                                    properties:
-                                      averageUtilization:
-                                        format: int32
-                                        type: integer
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type:
-                                        enum:
-                                          - Utilization
-                                          - Value
-                                          - AverageValue
-                                        type: string
-                                      value:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    type: object
-                                required:
-                                  - name
-                                  - target
-                                type: object
-                              type:
-                                enum:
-                                  - Resource
-                                  - External
-                                  - PodMetric
-                                type: string
-                            required:
-                              - type
-                            type: object
-                          type: array
                       type: object
                     automountServiceAccountToken:
                       type: boolean
@@ -1795,8 +1642,6 @@ spec:
                                 items:
                                   properties:
                                     name:
-                                      type: string
-                                    request:
                                       type: string
                                   required:
                                     - name
@@ -2554,8 +2399,6 @@ spec:
                                   properties:
                                     name:
                                       type: string
-                                    request:
-                                      type: string
                                   required:
                                     - name
                                   type: object
@@ -2797,10 +2640,6 @@ spec:
                       type: object
                     logger:
                       properties:
-                        metadataAnnotations:
-                          items:
-                            type: string
-                          type: array
                         metadataHeaders:
                           items:
                             type: string
@@ -2815,10 +2654,8 @@ spec:
                           type: string
                       type: object
                     maxReplicas:
-                      format: int32
                       type: integer
                     minReplicas:
-                      format: int32
                       type: integer
                     nodeName:
                       type: string
@@ -2861,10 +2698,13 @@ spec:
                         properties:
                           name:
                             type: string
-                          resourceClaimName:
-                            type: string
-                          resourceClaimTemplateName:
-                            type: string
+                          source:
+                            properties:
+                              resourceClaimName:
+                                type: string
+                              resourceClaimTemplateName:
+                                type: string
+                            type: object
                         required:
                           - name
                         type: object
@@ -2872,39 +2712,6 @@ spec:
                       x-kubernetes-list-map-keys:
                         - name
                       x-kubernetes-list-type: map
-                    resources:
-                      properties:
-                        claims:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              request:
-                                type: string
-                            required:
-                              - name
-                            type: object
-                          type: array
-                          x-kubernetes-list-map-keys:
-                            - name
-                          x-kubernetes-list-type: map
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
-                      type: object
                     restartPolicy:
                       type: string
                     runtimeClassName:
@@ -2916,14 +2723,7 @@ spec:
                         - concurrency
                         - rps
                       type: string
-                    scaleMetricType:
-                      enum:
-                        - Utilization
-                        - Value
-                        - AverageValue
-                      type: string
                     scaleTarget:
-                      format: int32
                       type: integer
                     schedulerName:
                       type: string
@@ -2963,8 +2763,6 @@ spec:
                         runAsUser:
                           format: int64
                           type: integer
-                        seLinuxChangePolicy:
-                          type: string
                         seLinuxOptions:
                           properties:
                             level:
@@ -2991,8 +2789,6 @@ spec:
                             type: integer
                           type: array
                           x-kubernetes-list-type: atomic
-                        supplementalGroupsPolicy:
-                          type: string
                         sysctls:
                           items:
                             properties:
@@ -3134,12 +2930,10 @@ spec:
                               diskURI:
                                 type: string
                               fsType:
-                                default: ext4
                                 type: string
                               kind:
                                 type: string
                               readOnly:
-                                default: false
                                 type: boolean
                             required:
                               - diskName
@@ -3499,13 +3293,6 @@ spec:
                             required:
                               - path
                             type: object
-                          image:
-                            properties:
-                              pullPolicy:
-                                type: string
-                              reference:
-                                type: string
-                            type: object
                           iscsi:
                             properties:
                               chapAuthDiscovery:
@@ -3519,7 +3306,6 @@ spec:
                               iqn:
                                 type: string
                               iscsiInterface:
-                                default: default
                                 type: string
                               lun:
                                 format: int32
@@ -3768,7 +3554,6 @@ spec:
                               image:
                                 type: string
                               keyring:
-                                default: /etc/ceph/keyring
                                 type: string
                               monitors:
                                 items:
@@ -3776,7 +3561,6 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               pool:
-                                default: rbd
                                 type: string
                               readOnly:
                                 type: boolean
@@ -3788,7 +3572,6 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
-                                default: admin
                                 type: string
                             required:
                               - image
@@ -3797,7 +3580,6 @@ spec:
                           scaleIO:
                             properties:
                               fsType:
-                                default: xfs
                                 type: string
                               gateway:
                                 type: string
@@ -3815,7 +3597,6 @@ spec:
                               sslEnabled:
                                 type: boolean
                               storageMode:
-                                default: ThinProvisioned
                                 type: string
                               storagePool:
                                 type: string
@@ -4338,157 +4119,6 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
-                    autoScaling:
-                      properties:
-                        metrics:
-                          items:
-                            properties:
-                              external:
-                                properties:
-                                  authenticationRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    required:
-                                      - name
-                                    type: object
-                                  metric:
-                                    properties:
-                                      authModes:
-                                        type: string
-                                      backend:
-                                        enum:
-                                          - prometheus
-                                          - graphite
-                                        type: string
-                                      namespace:
-                                        type: string
-                                      query:
-                                        type: string
-                                      serverAddress:
-                                        type: string
-                                    type: object
-                                  target:
-                                    properties:
-                                      averageUtilization:
-                                        format: int32
-                                        type: integer
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type:
-                                        enum:
-                                          - Utilization
-                                          - Value
-                                          - AverageValue
-                                        type: string
-                                      value:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    type: object
-                                required:
-                                  - metric
-                                  - target
-                                type: object
-                              podmetric:
-                                properties:
-                                  metric:
-                                    properties:
-                                      backend:
-                                        enum:
-                                          - opentelemetry
-                                        type: string
-                                      metricNames:
-                                        items:
-                                          type: string
-                                        type: array
-                                      operationOverTime:
-                                        type: string
-                                      query:
-                                        type: string
-                                      serverAddress:
-                                        type: string
-                                    type: object
-                                  target:
-                                    properties:
-                                      averageUtilization:
-                                        format: int32
-                                        type: integer
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type:
-                                        enum:
-                                          - Utilization
-                                          - Value
-                                          - AverageValue
-                                        type: string
-                                      value:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    type: object
-                                required:
-                                  - metric
-                                  - target
-                                type: object
-                              resource:
-                                properties:
-                                  name:
-                                    enum:
-                                      - cpu
-                                      - memory
-                                    type: string
-                                  target:
-                                    properties:
-                                      averageUtilization:
-                                        format: int32
-                                        type: integer
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type:
-                                        enum:
-                                          - Utilization
-                                          - Value
-                                          - AverageValue
-                                        type: string
-                                      value:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    type: object
-                                required:
-                                  - name
-                                  - target
-                                type: object
-                              type:
-                                enum:
-                                  - Resource
-                                  - External
-                                  - PodMetric
-                                type: string
-                            required:
-                              - type
-                            type: object
-                          type: array
-                      type: object
                     automountServiceAccountToken:
                       type: boolean
                     batcher:
@@ -4944,8 +4574,6 @@ spec:
                                 items:
                                   properties:
                                     name:
-                                      type: string
-                                    request:
                                       type: string
                                   required:
                                     - name
@@ -5687,8 +5315,6 @@ spec:
                                 properties:
                                   name:
                                     type: string
-                                  request:
-                                    type: string
                                 required:
                                   - name
                                 type: object
@@ -6390,8 +6016,6 @@ spec:
                                   properties:
                                     name:
                                       type: string
-                                    request:
-                                      type: string
                                   required:
                                     - name
                                   type: object
@@ -7067,8 +6691,6 @@ spec:
                                 properties:
                                   name:
                                     type: string
-                                  request:
-                                    type: string
                                 required:
                                   - name
                                 type: object
@@ -7320,10 +6942,6 @@ spec:
                       type: object
                     logger:
                       properties:
-                        metadataAnnotations:
-                          items:
-                            type: string
-                          type: array
                         metadataHeaders:
                           items:
                             type: string
@@ -7338,10 +6956,8 @@ spec:
                           type: string
                       type: object
                     maxReplicas:
-                      format: int32
                       type: integer
                     minReplicas:
-                      format: int32
                       type: integer
                     model:
                       properties:
@@ -7787,8 +7403,6 @@ spec:
                               items:
                                 properties:
                                   name:
-                                    type: string
-                                  request:
                                     type: string
                                 required:
                                   - name
@@ -8483,8 +8097,6 @@ spec:
                               items:
                                 properties:
                                   name:
-                                    type: string
-                                  request:
                                     type: string
                                 required:
                                   - name
@@ -9184,8 +8796,6 @@ spec:
                                 properties:
                                   name:
                                     type: string
-                                  request:
-                                    type: string
                                 required:
                                   - name
                                 type: object
@@ -9870,8 +9480,6 @@ spec:
                               items:
                                 properties:
                                   name:
-                                    type: string
-                                  request:
                                     type: string
                                 required:
                                   - name
@@ -10565,8 +10173,6 @@ spec:
                                 properties:
                                   name:
                                     type: string
-                                  request:
-                                    type: string
                                 required:
                                   - name
                                 type: object
@@ -10830,10 +10436,13 @@ spec:
                         properties:
                           name:
                             type: string
-                          resourceClaimName:
-                            type: string
-                          resourceClaimTemplateName:
-                            type: string
+                          source:
+                            properties:
+                              resourceClaimName:
+                                type: string
+                              resourceClaimTemplateName:
+                                type: string
+                            type: object
                         required:
                           - name
                         type: object
@@ -10841,39 +10450,6 @@ spec:
                       x-kubernetes-list-map-keys:
                         - name
                       x-kubernetes-list-type: map
-                    resources:
-                      properties:
-                        claims:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              request:
-                                type: string
-                            required:
-                              - name
-                            type: object
-                          type: array
-                          x-kubernetes-list-map-keys:
-                            - name
-                          x-kubernetes-list-type: map
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
-                      type: object
                     restartPolicy:
                       type: string
                     runtimeClassName:
@@ -10885,14 +10461,7 @@ spec:
                         - concurrency
                         - rps
                       type: string
-                    scaleMetricType:
-                      enum:
-                        - Utilization
-                        - Value
-                        - AverageValue
-                      type: string
                     scaleTarget:
-                      format: int32
                       type: integer
                     schedulerName:
                       type: string
@@ -10932,8 +10501,6 @@ spec:
                         runAsUser:
                           format: int64
                           type: integer
-                        seLinuxChangePolicy:
-                          type: string
                         seLinuxOptions:
                           properties:
                             level:
@@ -10960,8 +10527,6 @@ spec:
                             type: integer
                           type: array
                           x-kubernetes-list-type: atomic
-                        supplementalGroupsPolicy:
-                          type: string
                         sysctls:
                           items:
                             properties:
@@ -11430,8 +10995,6 @@ spec:
                               items:
                                 properties:
                                   name:
-                                    type: string
-                                  request:
                                     type: string
                                 required:
                                   - name
@@ -12119,8 +11682,6 @@ spec:
                               items:
                                 properties:
                                   name:
-                                    type: string
-                                  request:
                                     type: string
                                 required:
                                   - name
@@ -12887,8 +12448,6 @@ spec:
                                 properties:
                                   name:
                                     type: string
-                                  request:
-                                    type: string
                                 required:
                                   - name
                                 type: object
@@ -13164,12 +12723,10 @@ spec:
                               diskURI:
                                 type: string
                               fsType:
-                                default: ext4
                                 type: string
                               kind:
                                 type: string
                               readOnly:
-                                default: false
                                 type: boolean
                             required:
                               - diskName
@@ -13529,13 +13086,6 @@ spec:
                             required:
                               - path
                             type: object
-                          image:
-                            properties:
-                              pullPolicy:
-                                type: string
-                              reference:
-                                type: string
-                            type: object
                           iscsi:
                             properties:
                               chapAuthDiscovery:
@@ -13549,7 +13099,6 @@ spec:
                               iqn:
                                 type: string
                               iscsiInterface:
-                                default: default
                                 type: string
                               lun:
                                 format: int32
@@ -13798,7 +13347,6 @@ spec:
                               image:
                                 type: string
                               keyring:
-                                default: /etc/ceph/keyring
                                 type: string
                               monitors:
                                 items:
@@ -13806,7 +13354,6 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               pool:
-                                default: rbd
                                 type: string
                               readOnly:
                                 type: boolean
@@ -13818,7 +13365,6 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
-                                default: admin
                                 type: string
                             required:
                               - image
@@ -13827,7 +13373,6 @@ spec:
                           scaleIO:
                             properties:
                               fsType:
-                                default: xfs
                                 type: string
                               gateway:
                                 type: string
@@ -13845,7 +13390,6 @@ spec:
                               sslEnabled:
                                 type: boolean
                               storageMode:
-                                default: ThinProvisioned
                                 type: string
                               storagePool:
                                 type: string
@@ -14808,8 +14352,6 @@ spec:
                                       properties:
                                         name:
                                           type: string
-                                        request:
-                                          type: string
                                       required:
                                         - name
                                       type: object
@@ -15514,8 +15056,6 @@ spec:
                                     items:
                                       properties:
                                         name:
-                                          type: string
-                                        request:
                                           type: string
                                       required:
                                         - name
@@ -16230,8 +15770,6 @@ spec:
                                       properties:
                                         name:
                                           type: string
-                                        request:
-                                          type: string
                                       required:
                                         - name
                                       type: object
@@ -16512,10 +16050,13 @@ spec:
                             properties:
                               name:
                                 type: string
-                              resourceClaimName:
-                                type: string
-                              resourceClaimTemplateName:
-                                type: string
+                              source:
+                                properties:
+                                  resourceClaimName:
+                                    type: string
+                                  resourceClaimTemplateName:
+                                    type: string
+                                type: object
                             required:
                               - name
                             type: object
@@ -16523,39 +16064,6 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
-                        resources:
-                          properties:
-                            claims:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  request:
-                                    type: string
-                                required:
-                                  - name
-                                type: object
-                              type: array
-                              x-kubernetes-list-map-keys:
-                                - name
-                              x-kubernetes-list-type: map
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              type: object
-                          type: object
                         restartPolicy:
                           type: string
                         runtimeClassName:
@@ -16598,8 +16106,6 @@ spec:
                             runAsUser:
                               format: int64
                               type: integer
-                            seLinuxChangePolicy:
-                              type: string
                             seLinuxOptions:
                               properties:
                                 level:
@@ -16626,8 +16132,6 @@ spec:
                                 type: integer
                               type: array
                               x-kubernetes-list-type: atomic
-                            supplementalGroupsPolicy:
-                              type: string
                             sysctls:
                               items:
                                 properties:
@@ -16768,12 +16272,10 @@ spec:
                                   diskURI:
                                     type: string
                                   fsType:
-                                    default: ext4
                                     type: string
                                   kind:
                                     type: string
                                   readOnly:
-                                    default: false
                                     type: boolean
                                 required:
                                   - diskName
@@ -17133,13 +16635,6 @@ spec:
                                 required:
                                   - path
                                 type: object
-                              image:
-                                properties:
-                                  pullPolicy:
-                                    type: string
-                                  reference:
-                                    type: string
-                                type: object
                               iscsi:
                                 properties:
                                   chapAuthDiscovery:
@@ -17153,7 +16648,6 @@ spec:
                                   iqn:
                                     type: string
                                   iscsiInterface:
-                                    default: default
                                     type: string
                                   lun:
                                     format: int32
@@ -17402,7 +16896,6 @@ spec:
                                   image:
                                     type: string
                                   keyring:
-                                    default: /etc/ceph/keyring
                                     type: string
                                   monitors:
                                     items:
@@ -17410,7 +16903,6 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   pool:
-                                    default: rbd
                                     type: string
                                   readOnly:
                                     type: boolean
@@ -17422,7 +16914,6 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   user:
-                                    default: admin
                                     type: string
                                 required:
                                   - image
@@ -17431,7 +16922,6 @@ spec:
                               scaleIO:
                                 properties:
                                   fsType:
-                                    default: xfs
                                     type: string
                                   gateway:
                                     type: string
@@ -17449,7 +16939,6 @@ spec:
                                   sslEnabled:
                                     type: boolean
                                   storageMode:
-                                    default: ThinProvisioned
                                     type: string
                                   storagePool:
                                     type: string
@@ -17959,8 +17448,6 @@ spec:
                               items:
                                 properties:
                                   name:
-                                    type: string
-                                  request:
                                     type: string
                                 required:
                                   - name
@@ -18660,157 +18147,6 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
-                    autoScaling:
-                      properties:
-                        metrics:
-                          items:
-                            properties:
-                              external:
-                                properties:
-                                  authenticationRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                    required:
-                                      - name
-                                    type: object
-                                  metric:
-                                    properties:
-                                      authModes:
-                                        type: string
-                                      backend:
-                                        enum:
-                                          - prometheus
-                                          - graphite
-                                        type: string
-                                      namespace:
-                                        type: string
-                                      query:
-                                        type: string
-                                      serverAddress:
-                                        type: string
-                                    type: object
-                                  target:
-                                    properties:
-                                      averageUtilization:
-                                        format: int32
-                                        type: integer
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type:
-                                        enum:
-                                          - Utilization
-                                          - Value
-                                          - AverageValue
-                                        type: string
-                                      value:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    type: object
-                                required:
-                                  - metric
-                                  - target
-                                type: object
-                              podmetric:
-                                properties:
-                                  metric:
-                                    properties:
-                                      backend:
-                                        enum:
-                                          - opentelemetry
-                                        type: string
-                                      metricNames:
-                                        items:
-                                          type: string
-                                        type: array
-                                      operationOverTime:
-                                        type: string
-                                      query:
-                                        type: string
-                                      serverAddress:
-                                        type: string
-                                    type: object
-                                  target:
-                                    properties:
-                                      averageUtilization:
-                                        format: int32
-                                        type: integer
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type:
-                                        enum:
-                                          - Utilization
-                                          - Value
-                                          - AverageValue
-                                        type: string
-                                      value:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    type: object
-                                required:
-                                  - metric
-                                  - target
-                                type: object
-                              resource:
-                                properties:
-                                  name:
-                                    enum:
-                                      - cpu
-                                      - memory
-                                    type: string
-                                  target:
-                                    properties:
-                                      averageUtilization:
-                                        format: int32
-                                        type: integer
-                                      averageValue:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      type:
-                                        enum:
-                                          - Utilization
-                                          - Value
-                                          - AverageValue
-                                        type: string
-                                      value:
-                                        anyOf:
-                                          - type: integer
-                                          - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                    type: object
-                                required:
-                                  - name
-                                  - target
-                                type: object
-                              type:
-                                enum:
-                                  - Resource
-                                  - External
-                                  - PodMetric
-                                type: string
-                            required:
-                              - type
-                            type: object
-                          type: array
-                      type: object
                     automountServiceAccountToken:
                       type: boolean
                     batcher:
@@ -19266,8 +18602,6 @@ spec:
                                 items:
                                   properties:
                                     name:
-                                      type: string
-                                    request:
                                       type: string
                                   required:
                                     - name
@@ -20025,8 +19359,6 @@ spec:
                                   properties:
                                     name:
                                       type: string
-                                    request:
-                                      type: string
                                   required:
                                     - name
                                   type: object
@@ -20268,10 +19600,6 @@ spec:
                       type: object
                     logger:
                       properties:
-                        metadataAnnotations:
-                          items:
-                            type: string
-                          type: array
                         metadataHeaders:
                           items:
                             type: string
@@ -20286,10 +19614,8 @@ spec:
                           type: string
                       type: object
                     maxReplicas:
-                      format: int32
                       type: integer
                     minReplicas:
-                      format: int32
                       type: integer
                     nodeName:
                       type: string
@@ -20332,10 +19658,13 @@ spec:
                         properties:
                           name:
                             type: string
-                          resourceClaimName:
-                            type: string
-                          resourceClaimTemplateName:
-                            type: string
+                          source:
+                            properties:
+                              resourceClaimName:
+                                type: string
+                              resourceClaimTemplateName:
+                                type: string
+                            type: object
                         required:
                           - name
                         type: object
@@ -20343,39 +19672,6 @@ spec:
                       x-kubernetes-list-map-keys:
                         - name
                       x-kubernetes-list-type: map
-                    resources:
-                      properties:
-                        claims:
-                          items:
-                            properties:
-                              name:
-                                type: string
-                              request:
-                                type: string
-                            required:
-                              - name
-                            type: object
-                          type: array
-                          x-kubernetes-list-map-keys:
-                            - name
-                          x-kubernetes-list-type: map
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          type: object
-                      type: object
                     restartPolicy:
                       type: string
                     runtimeClassName:
@@ -20387,14 +19683,7 @@ spec:
                         - concurrency
                         - rps
                       type: string
-                    scaleMetricType:
-                      enum:
-                        - Utilization
-                        - Value
-                        - AverageValue
-                      type: string
                     scaleTarget:
-                      format: int32
                       type: integer
                     schedulerName:
                       type: string
@@ -20434,8 +19723,6 @@ spec:
                         runAsUser:
                           format: int64
                           type: integer
-                        seLinuxChangePolicy:
-                          type: string
                         seLinuxOptions:
                           properties:
                             level:
@@ -20462,8 +19749,6 @@ spec:
                             type: integer
                           type: array
                           x-kubernetes-list-type: atomic
-                        supplementalGroupsPolicy:
-                          type: string
                         sysctls:
                           items:
                             properties:
@@ -20605,12 +19890,10 @@ spec:
                               diskURI:
                                 type: string
                               fsType:
-                                default: ext4
                                 type: string
                               kind:
                                 type: string
                               readOnly:
-                                default: false
                                 type: boolean
                             required:
                               - diskName
@@ -20970,13 +20253,6 @@ spec:
                             required:
                               - path
                             type: object
-                          image:
-                            properties:
-                              pullPolicy:
-                                type: string
-                              reference:
-                                type: string
-                            type: object
                           iscsi:
                             properties:
                               chapAuthDiscovery:
@@ -20990,7 +20266,6 @@ spec:
                               iqn:
                                 type: string
                               iscsiInterface:
-                                default: default
                                 type: string
                               lun:
                                 format: int32
@@ -21239,7 +20514,6 @@ spec:
                               image:
                                 type: string
                               keyring:
-                                default: /etc/ceph/keyring
                                 type: string
                               monitors:
                                 items:
@@ -21247,7 +20521,6 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               pool:
-                                default: rbd
                                 type: string
                               readOnly:
                                 type: boolean
@@ -21259,7 +20532,6 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
-                                default: admin
                                 type: string
                             required:
                               - image
@@ -21268,7 +20540,6 @@ spec:
                           scaleIO:
                             properties:
                               fsType:
-                                default: xfs
                                 type: string
                               gateway:
                                 type: string
@@ -21286,7 +20557,6 @@ spec:
                               sslEnabled:
                                 type: boolean
                               storageMode:
-                                default: ThinProvisioned
                                 type: string
                               storagePool:
                                 type: string
@@ -21449,8 +20719,6 @@ spec:
                       - type
                     type: object
                   type: array
-                deploymentMode:
-                  type: string
                 modelStatus:
                   properties:
                     copies:

--- a/config/crd/bases/serving.kserve.io_servingruntimes.yaml
+++ b/config/crd/bases/serving.kserve.io_servingruntimes.yaml
@@ -1002,8 +1002,6 @@ spec:
                               properties:
                                 name:
                                   type: string
-                                request:
-                                  type: string
                               required:
                                 - name
                               type: object
@@ -1338,12 +1336,10 @@ spec:
                           diskURI:
                             type: string
                           fsType:
-                            default: ext4
                             type: string
                           kind:
                             type: string
                           readOnly:
-                            default: false
                             type: boolean
                         required:
                           - diskName
@@ -1703,13 +1699,6 @@ spec:
                         required:
                           - path
                         type: object
-                      image:
-                        properties:
-                          pullPolicy:
-                            type: string
-                          reference:
-                            type: string
-                        type: object
                       iscsi:
                         properties:
                           chapAuthDiscovery:
@@ -1723,7 +1712,6 @@ spec:
                           iqn:
                             type: string
                           iscsiInterface:
-                            default: default
                             type: string
                           lun:
                             format: int32
@@ -1972,7 +1960,6 @@ spec:
                           image:
                             type: string
                           keyring:
-                            default: /etc/ceph/keyring
                             type: string
                           monitors:
                             items:
@@ -1980,7 +1967,6 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           pool:
-                            default: rbd
                             type: string
                           readOnly:
                             type: boolean
@@ -1992,7 +1978,6 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           user:
-                            default: admin
                             type: string
                         required:
                           - image
@@ -2001,7 +1986,6 @@ spec:
                       scaleIO:
                         properties:
                           fsType:
-                            default: xfs
                             type: string
                           gateway:
                             type: string
@@ -2019,7 +2003,6 @@ spec:
                           sslEnabled:
                             type: boolean
                           storageMode:
-                            default: ThinProvisioned
                             type: string
                           storagePool:
                             type: string
@@ -2981,8 +2964,6 @@ spec:
                                   properties:
                                     name:
                                       type: string
-                                    request:
-                                      type: string
                                   required:
                                     - name
                                   type: object
@@ -3283,12 +3264,10 @@ spec:
                               diskURI:
                                 type: string
                               fsType:
-                                default: ext4
                                 type: string
                               kind:
                                 type: string
                               readOnly:
-                                default: false
                                 type: boolean
                             required:
                               - diskName
@@ -3648,13 +3627,6 @@ spec:
                             required:
                               - path
                             type: object
-                          image:
-                            properties:
-                              pullPolicy:
-                                type: string
-                              reference:
-                                type: string
-                            type: object
                           iscsi:
                             properties:
                               chapAuthDiscovery:
@@ -3668,7 +3640,6 @@ spec:
                               iqn:
                                 type: string
                               iscsiInterface:
-                                default: default
                                 type: string
                               lun:
                                 format: int32
@@ -3917,7 +3888,6 @@ spec:
                               image:
                                 type: string
                               keyring:
-                                default: /etc/ceph/keyring
                                 type: string
                               monitors:
                                 items:
@@ -3925,7 +3895,6 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               pool:
-                                default: rbd
                                 type: string
                               readOnly:
                                 type: boolean
@@ -3937,7 +3906,6 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
-                                default: admin
                                 type: string
                             required:
                               - image
@@ -3946,7 +3914,6 @@ spec:
                           scaleIO:
                             properties:
                               fsType:
-                                default: xfs
                                 type: string
                               gateway:
                                 type: string
@@ -3964,7 +3931,6 @@ spec:
                               sslEnabled:
                                 type: boolean
                               storageMode:
-                                default: ThinProvisioned
                                 type: string
                               storagePool:
                                 type: string


### PR DESCRIPTION
#### Motivation
Reverting CRD changes done for kserve release-v0.15 that are no longer needed since we are using kserve release-v0.14
#### Modifications

#### Result


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
