### PR TITLE
Restoring crd changes done for kserve relese-v0.15

### DIFF
--- a/config/crd/bases/serving.kserve.io_inferenceservices.yaml
+++ b/config/crd/bases/serving.kserve.io_inferenceservices.yaml
@@ -936,6 +936,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                   - name
                                 type: object
@@ -1186,6 +1188,157 @@ spec:
                           x-kubernetes-list-type: map
                         workingDir:
                           type: string
+                      type: object
+                    autoScaling:
+                      properties:
+                        metrics:
+                          items:
+                            properties:
+                              external:
+                                properties:
+                                  authenticationRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  metric:
+                                    properties:
+                                      authModes:
+                                        type: string
+                                      backend:
+                                        enum:
+                                          - prometheus
+                                          - graphite
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      query:
+                                        type: string
+                                      serverAddress:
+                                        type: string
+                                    type: object
+                                  target:
+                                    properties:
+                                      averageUtilization:
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        enum:
+                                          - Utilization
+                                          - Value
+                                          - AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                required:
+                                  - metric
+                                  - target
+                                type: object
+                              podmetric:
+                                properties:
+                                  metric:
+                                    properties:
+                                      backend:
+                                        enum:
+                                          - opentelemetry
+                                        type: string
+                                      metricNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                      operationOverTime:
+                                        type: string
+                                      query:
+                                        type: string
+                                      serverAddress:
+                                        type: string
+                                    type: object
+                                  target:
+                                    properties:
+                                      averageUtilization:
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        enum:
+                                          - Utilization
+                                          - Value
+                                          - AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                required:
+                                  - metric
+                                  - target
+                                type: object
+                              resource:
+                                properties:
+                                  name:
+                                    enum:
+                                      - cpu
+                                      - memory
+                                    type: string
+                                  target:
+                                    properties:
+                                      averageUtilization:
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        enum:
+                                          - Utilization
+                                          - Value
+                                          - AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                required:
+                                  - name
+                                  - target
+                                type: object
+                              type:
+                                enum:
+                                  - Resource
+                                  - External
+                                  - PodMetric
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          type: array
                       type: object
                     automountServiceAccountToken:
                       type: boolean
@@ -1642,6 +1795,8 @@ spec:
                                 items:
                                   properties:
                                     name:
+                                      type: string
+                                    request:
                                       type: string
                                   required:
                                     - name
@@ -2399,6 +2554,8 @@ spec:
                                   properties:
                                     name:
                                       type: string
+                                    request:
+                                      type: string
                                   required:
                                     - name
                                   type: object
@@ -2640,6 +2797,10 @@ spec:
                       type: object
                     logger:
                       properties:
+                        metadataAnnotations:
+                          items:
+                            type: string
+                          type: array
                         metadataHeaders:
                           items:
                             type: string
@@ -2654,8 +2815,10 @@ spec:
                           type: string
                       type: object
                     maxReplicas:
+                      format: int32
                       type: integer
                     minReplicas:
+                      format: int32
                       type: integer
                     nodeName:
                       type: string
@@ -2698,13 +2861,10 @@ spec:
                         properties:
                           name:
                             type: string
-                          source:
-                            properties:
-                              resourceClaimName:
-                                type: string
-                              resourceClaimTemplateName:
-                                type: string
-                            type: object
+                          resourceClaimName:
+                            type: string
+                          resourceClaimTemplateName:
+                            type: string
                         required:
                           - name
                         type: object
@@ -2712,6 +2872,39 @@ spec:
                       x-kubernetes-list-map-keys:
                         - name
                       x-kubernetes-list-type: map
+                    resources:
+                      properties:
+                        claims:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              request:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
                     restartPolicy:
                       type: string
                     runtimeClassName:
@@ -2723,7 +2916,14 @@ spec:
                         - concurrency
                         - rps
                       type: string
+                    scaleMetricType:
+                      enum:
+                        - Utilization
+                        - Value
+                        - AverageValue
+                      type: string
                     scaleTarget:
+                      format: int32
                       type: integer
                     schedulerName:
                       type: string
@@ -2763,6 +2963,8 @@ spec:
                         runAsUser:
                           format: int64
                           type: integer
+                        seLinuxChangePolicy:
+                          type: string
                         seLinuxOptions:
                           properties:
                             level:
@@ -2789,6 +2991,8 @@ spec:
                             type: integer
                           type: array
                           x-kubernetes-list-type: atomic
+                        supplementalGroupsPolicy:
+                          type: string
                         sysctls:
                           items:
                             properties:
@@ -2930,10 +3134,12 @@ spec:
                               diskURI:
                                 type: string
                               fsType:
+                                default: ext4
                                 type: string
                               kind:
                                 type: string
                               readOnly:
+                                default: false
                                 type: boolean
                             required:
                               - diskName
@@ -3293,6 +3499,13 @@ spec:
                             required:
                               - path
                             type: object
+                          image:
+                            properties:
+                              pullPolicy:
+                                type: string
+                              reference:
+                                type: string
+                            type: object
                           iscsi:
                             properties:
                               chapAuthDiscovery:
@@ -3306,6 +3519,7 @@ spec:
                               iqn:
                                 type: string
                               iscsiInterface:
+                                default: default
                                 type: string
                               lun:
                                 format: int32
@@ -3554,6 +3768,7 @@ spec:
                               image:
                                 type: string
                               keyring:
+                                default: /etc/ceph/keyring
                                 type: string
                               monitors:
                                 items:
@@ -3561,6 +3776,7 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               pool:
+                                default: rbd
                                 type: string
                               readOnly:
                                 type: boolean
@@ -3572,6 +3788,7 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
+                                default: admin
                                 type: string
                             required:
                               - image
@@ -3580,6 +3797,7 @@ spec:
                           scaleIO:
                             properties:
                               fsType:
+                                default: xfs
                                 type: string
                               gateway:
                                 type: string
@@ -3597,6 +3815,7 @@ spec:
                               sslEnabled:
                                 type: boolean
                               storageMode:
+                                default: ThinProvisioned
                                 type: string
                               storagePool:
                                 type: string
@@ -4119,6 +4338,157 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    autoScaling:
+                      properties:
+                        metrics:
+                          items:
+                            properties:
+                              external:
+                                properties:
+                                  authenticationRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  metric:
+                                    properties:
+                                      authModes:
+                                        type: string
+                                      backend:
+                                        enum:
+                                          - prometheus
+                                          - graphite
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      query:
+                                        type: string
+                                      serverAddress:
+                                        type: string
+                                    type: object
+                                  target:
+                                    properties:
+                                      averageUtilization:
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        enum:
+                                          - Utilization
+                                          - Value
+                                          - AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                required:
+                                  - metric
+                                  - target
+                                type: object
+                              podmetric:
+                                properties:
+                                  metric:
+                                    properties:
+                                      backend:
+                                        enum:
+                                          - opentelemetry
+                                        type: string
+                                      metricNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                      operationOverTime:
+                                        type: string
+                                      query:
+                                        type: string
+                                      serverAddress:
+                                        type: string
+                                    type: object
+                                  target:
+                                    properties:
+                                      averageUtilization:
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        enum:
+                                          - Utilization
+                                          - Value
+                                          - AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                required:
+                                  - metric
+                                  - target
+                                type: object
+                              resource:
+                                properties:
+                                  name:
+                                    enum:
+                                      - cpu
+                                      - memory
+                                    type: string
+                                  target:
+                                    properties:
+                                      averageUtilization:
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        enum:
+                                          - Utilization
+                                          - Value
+                                          - AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                required:
+                                  - name
+                                  - target
+                                type: object
+                              type:
+                                enum:
+                                  - Resource
+                                  - External
+                                  - PodMetric
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          type: array
+                      type: object
                     automountServiceAccountToken:
                       type: boolean
                     batcher:
@@ -4574,6 +4944,8 @@ spec:
                                 items:
                                   properties:
                                     name:
+                                      type: string
+                                    request:
                                       type: string
                                   required:
                                     - name
@@ -5315,6 +5687,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                   - name
                                 type: object
@@ -6016,6 +6390,8 @@ spec:
                                   properties:
                                     name:
                                       type: string
+                                    request:
+                                      type: string
                                   required:
                                     - name
                                   type: object
@@ -6691,6 +7067,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                   - name
                                 type: object
@@ -6942,6 +7320,10 @@ spec:
                       type: object
                     logger:
                       properties:
+                        metadataAnnotations:
+                          items:
+                            type: string
+                          type: array
                         metadataHeaders:
                           items:
                             type: string
@@ -6956,8 +7338,10 @@ spec:
                           type: string
                       type: object
                     maxReplicas:
+                      format: int32
                       type: integer
                     minReplicas:
+                      format: int32
                       type: integer
                     model:
                       properties:
@@ -7403,6 +7787,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                   - name
@@ -8097,6 +8483,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                   - name
@@ -8796,6 +9184,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                   - name
                                 type: object
@@ -9480,6 +9870,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                   - name
@@ -10173,6 +10565,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                   - name
                                 type: object
@@ -10436,13 +10830,10 @@ spec:
                         properties:
                           name:
                             type: string
-                          source:
-                            properties:
-                              resourceClaimName:
-                                type: string
-                              resourceClaimTemplateName:
-                                type: string
-                            type: object
+                          resourceClaimName:
+                            type: string
+                          resourceClaimTemplateName:
+                            type: string
                         required:
                           - name
                         type: object
@@ -10450,6 +10841,39 @@ spec:
                       x-kubernetes-list-map-keys:
                         - name
                       x-kubernetes-list-type: map
+                    resources:
+                      properties:
+                        claims:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              request:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
                     restartPolicy:
                       type: string
                     runtimeClassName:
@@ -10461,7 +10885,14 @@ spec:
                         - concurrency
                         - rps
                       type: string
+                    scaleMetricType:
+                      enum:
+                        - Utilization
+                        - Value
+                        - AverageValue
+                      type: string
                     scaleTarget:
+                      format: int32
                       type: integer
                     schedulerName:
                       type: string
@@ -10501,6 +10932,8 @@ spec:
                         runAsUser:
                           format: int64
                           type: integer
+                        seLinuxChangePolicy:
+                          type: string
                         seLinuxOptions:
                           properties:
                             level:
@@ -10527,6 +10960,8 @@ spec:
                             type: integer
                           type: array
                           x-kubernetes-list-type: atomic
+                        supplementalGroupsPolicy:
+                          type: string
                         sysctls:
                           items:
                             properties:
@@ -10995,6 +11430,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                   - name
@@ -11682,6 +12119,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                   - name
@@ -12448,6 +12887,8 @@ spec:
                                 properties:
                                   name:
                                     type: string
+                                  request:
+                                    type: string
                                 required:
                                   - name
                                 type: object
@@ -12723,10 +13164,12 @@ spec:
                               diskURI:
                                 type: string
                               fsType:
+                                default: ext4
                                 type: string
                               kind:
                                 type: string
                               readOnly:
+                                default: false
                                 type: boolean
                             required:
                               - diskName
@@ -13086,6 +13529,13 @@ spec:
                             required:
                               - path
                             type: object
+                          image:
+                            properties:
+                              pullPolicy:
+                                type: string
+                              reference:
+                                type: string
+                            type: object
                           iscsi:
                             properties:
                               chapAuthDiscovery:
@@ -13099,6 +13549,7 @@ spec:
                               iqn:
                                 type: string
                               iscsiInterface:
+                                default: default
                                 type: string
                               lun:
                                 format: int32
@@ -13347,6 +13798,7 @@ spec:
                               image:
                                 type: string
                               keyring:
+                                default: /etc/ceph/keyring
                                 type: string
                               monitors:
                                 items:
@@ -13354,6 +13806,7 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               pool:
+                                default: rbd
                                 type: string
                               readOnly:
                                 type: boolean
@@ -13365,6 +13818,7 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
+                                default: admin
                                 type: string
                             required:
                               - image
@@ -13373,6 +13827,7 @@ spec:
                           scaleIO:
                             properties:
                               fsType:
+                                default: xfs
                                 type: string
                               gateway:
                                 type: string
@@ -13390,6 +13845,7 @@ spec:
                               sslEnabled:
                                 type: boolean
                               storageMode:
+                                default: ThinProvisioned
                                 type: string
                               storagePool:
                                 type: string
@@ -14352,6 +14808,8 @@ spec:
                                       properties:
                                         name:
                                           type: string
+                                        request:
+                                          type: string
                                       required:
                                         - name
                                       type: object
@@ -15056,6 +15514,8 @@ spec:
                                     items:
                                       properties:
                                         name:
+                                          type: string
+                                        request:
                                           type: string
                                       required:
                                         - name
@@ -15770,6 +16230,8 @@ spec:
                                       properties:
                                         name:
                                           type: string
+                                        request:
+                                          type: string
                                       required:
                                         - name
                                       type: object
@@ -16050,13 +16512,10 @@ spec:
                             properties:
                               name:
                                 type: string
-                              source:
-                                properties:
-                                  resourceClaimName:
-                                    type: string
-                                  resourceClaimTemplateName:
-                                    type: string
-                                type: object
+                              resourceClaimName:
+                                type: string
+                              resourceClaimTemplateName:
+                                type: string
                             required:
                               - name
                             type: object
@@ -16064,6 +16523,39 @@ spec:
                           x-kubernetes-list-map-keys:
                             - name
                           x-kubernetes-list-type: map
+                        resources:
+                          properties:
+                            claims:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  request:
+                                    type: string
+                                required:
+                                  - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - name
+                              x-kubernetes-list-type: map
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              type: object
+                          type: object
                         restartPolicy:
                           type: string
                         runtimeClassName:
@@ -16106,6 +16598,8 @@ spec:
                             runAsUser:
                               format: int64
                               type: integer
+                            seLinuxChangePolicy:
+                              type: string
                             seLinuxOptions:
                               properties:
                                 level:
@@ -16132,6 +16626,8 @@ spec:
                                 type: integer
                               type: array
                               x-kubernetes-list-type: atomic
+                            supplementalGroupsPolicy:
+                              type: string
                             sysctls:
                               items:
                                 properties:
@@ -16272,10 +16768,12 @@ spec:
                                   diskURI:
                                     type: string
                                   fsType:
+                                    default: ext4
                                     type: string
                                   kind:
                                     type: string
                                   readOnly:
+                                    default: false
                                     type: boolean
                                 required:
                                   - diskName
@@ -16635,6 +17133,13 @@ spec:
                                 required:
                                   - path
                                 type: object
+                              image:
+                                properties:
+                                  pullPolicy:
+                                    type: string
+                                  reference:
+                                    type: string
+                                type: object
                               iscsi:
                                 properties:
                                   chapAuthDiscovery:
@@ -16648,6 +17153,7 @@ spec:
                                   iqn:
                                     type: string
                                   iscsiInterface:
+                                    default: default
                                     type: string
                                   lun:
                                     format: int32
@@ -16896,6 +17402,7 @@ spec:
                                   image:
                                     type: string
                                   keyring:
+                                    default: /etc/ceph/keyring
                                     type: string
                                   monitors:
                                     items:
@@ -16903,6 +17410,7 @@ spec:
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   pool:
+                                    default: rbd
                                     type: string
                                   readOnly:
                                     type: boolean
@@ -16914,6 +17422,7 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   user:
+                                    default: admin
                                     type: string
                                 required:
                                   - image
@@ -16922,6 +17431,7 @@ spec:
                               scaleIO:
                                 properties:
                                   fsType:
+                                    default: xfs
                                     type: string
                                   gateway:
                                     type: string
@@ -16939,6 +17449,7 @@ spec:
                                   sslEnabled:
                                     type: boolean
                                   storageMode:
+                                    default: ThinProvisioned
                                     type: string
                                   storagePool:
                                     type: string
@@ -17448,6 +17959,8 @@ spec:
                               items:
                                 properties:
                                   name:
+                                    type: string
+                                  request:
                                     type: string
                                 required:
                                   - name
@@ -18147,6 +18660,157 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    autoScaling:
+                      properties:
+                        metrics:
+                          items:
+                            properties:
+                              external:
+                                properties:
+                                  authenticationRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    required:
+                                      - name
+                                    type: object
+                                  metric:
+                                    properties:
+                                      authModes:
+                                        type: string
+                                      backend:
+                                        enum:
+                                          - prometheus
+                                          - graphite
+                                        type: string
+                                      namespace:
+                                        type: string
+                                      query:
+                                        type: string
+                                      serverAddress:
+                                        type: string
+                                    type: object
+                                  target:
+                                    properties:
+                                      averageUtilization:
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        enum:
+                                          - Utilization
+                                          - Value
+                                          - AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                required:
+                                  - metric
+                                  - target
+                                type: object
+                              podmetric:
+                                properties:
+                                  metric:
+                                    properties:
+                                      backend:
+                                        enum:
+                                          - opentelemetry
+                                        type: string
+                                      metricNames:
+                                        items:
+                                          type: string
+                                        type: array
+                                      operationOverTime:
+                                        type: string
+                                      query:
+                                        type: string
+                                      serverAddress:
+                                        type: string
+                                    type: object
+                                  target:
+                                    properties:
+                                      averageUtilization:
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        enum:
+                                          - Utilization
+                                          - Value
+                                          - AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                required:
+                                  - metric
+                                  - target
+                                type: object
+                              resource:
+                                properties:
+                                  name:
+                                    enum:
+                                      - cpu
+                                      - memory
+                                    type: string
+                                  target:
+                                    properties:
+                                      averageUtilization:
+                                        format: int32
+                                        type: integer
+                                      averageValue:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      type:
+                                        enum:
+                                          - Utilization
+                                          - Value
+                                          - AverageValue
+                                        type: string
+                                      value:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                required:
+                                  - name
+                                  - target
+                                type: object
+                              type:
+                                enum:
+                                  - Resource
+                                  - External
+                                  - PodMetric
+                                type: string
+                            required:
+                              - type
+                            type: object
+                          type: array
+                      type: object
                     automountServiceAccountToken:
                       type: boolean
                     batcher:
@@ -18602,6 +19266,8 @@ spec:
                                 items:
                                   properties:
                                     name:
+                                      type: string
+                                    request:
                                       type: string
                                   required:
                                     - name
@@ -19359,6 +20025,8 @@ spec:
                                   properties:
                                     name:
                                       type: string
+                                    request:
+                                      type: string
                                   required:
                                     - name
                                   type: object
@@ -19600,6 +20268,10 @@ spec:
                       type: object
                     logger:
                       properties:
+                        metadataAnnotations:
+                          items:
+                            type: string
+                          type: array
                         metadataHeaders:
                           items:
                             type: string
@@ -19614,8 +20286,10 @@ spec:
                           type: string
                       type: object
                     maxReplicas:
+                      format: int32
                       type: integer
                     minReplicas:
+                      format: int32
                       type: integer
                     nodeName:
                       type: string
@@ -19658,13 +20332,10 @@ spec:
                         properties:
                           name:
                             type: string
-                          source:
-                            properties:
-                              resourceClaimName:
-                                type: string
-                              resourceClaimTemplateName:
-                                type: string
-                            type: object
+                          resourceClaimName:
+                            type: string
+                          resourceClaimTemplateName:
+                            type: string
                         required:
                           - name
                         type: object
@@ -19672,6 +20343,39 @@ spec:
                       x-kubernetes-list-map-keys:
                         - name
                       x-kubernetes-list-type: map
+                    resources:
+                      properties:
+                        claims:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              request:
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
                     restartPolicy:
                       type: string
                     runtimeClassName:
@@ -19683,7 +20387,14 @@ spec:
                         - concurrency
                         - rps
                       type: string
+                    scaleMetricType:
+                      enum:
+                        - Utilization
+                        - Value
+                        - AverageValue
+                      type: string
                     scaleTarget:
+                      format: int32
                       type: integer
                     schedulerName:
                       type: string
@@ -19723,6 +20434,8 @@ spec:
                         runAsUser:
                           format: int64
                           type: integer
+                        seLinuxChangePolicy:
+                          type: string
                         seLinuxOptions:
                           properties:
                             level:
@@ -19749,6 +20462,8 @@ spec:
                             type: integer
                           type: array
                           x-kubernetes-list-type: atomic
+                        supplementalGroupsPolicy:
+                          type: string
                         sysctls:
                           items:
                             properties:
@@ -19890,10 +20605,12 @@ spec:
                               diskURI:
                                 type: string
                               fsType:
+                                default: ext4
                                 type: string
                               kind:
                                 type: string
                               readOnly:
+                                default: false
                                 type: boolean
                             required:
                               - diskName
@@ -20253,6 +20970,13 @@ spec:
                             required:
                               - path
                             type: object
+                          image:
+                            properties:
+                              pullPolicy:
+                                type: string
+                              reference:
+                                type: string
+                            type: object
                           iscsi:
                             properties:
                               chapAuthDiscovery:
@@ -20266,6 +20990,7 @@ spec:
                               iqn:
                                 type: string
                               iscsiInterface:
+                                default: default
                                 type: string
                               lun:
                                 format: int32
@@ -20514,6 +21239,7 @@ spec:
                               image:
                                 type: string
                               keyring:
+                                default: /etc/ceph/keyring
                                 type: string
                               monitors:
                                 items:
@@ -20521,6 +21247,7 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               pool:
+                                default: rbd
                                 type: string
                               readOnly:
                                 type: boolean
@@ -20532,6 +21259,7 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
+                                default: admin
                                 type: string
                             required:
                               - image
@@ -20540,6 +21268,7 @@ spec:
                           scaleIO:
                             properties:
                               fsType:
+                                default: xfs
                                 type: string
                               gateway:
                                 type: string
@@ -20557,6 +21286,7 @@ spec:
                               sslEnabled:
                                 type: boolean
                               storageMode:
+                                default: ThinProvisioned
                                 type: string
                               storagePool:
                                 type: string
@@ -20719,6 +21449,8 @@ spec:
                       - type
                     type: object
                   type: array
+                deploymentMode:
+                  type: string
                 modelStatus:
                   properties:
                     copies:

--- a/config/crd/bases/serving.kserve.io_servingruntimes.yaml
+++ b/config/crd/bases/serving.kserve.io_servingruntimes.yaml
@@ -1002,6 +1002,8 @@ spec:
                               properties:
                                 name:
                                   type: string
+                                request:
+                                  type: string
                               required:
                                 - name
                               type: object
@@ -1336,10 +1338,12 @@ spec:
                           diskURI:
                             type: string
                           fsType:
+                            default: ext4
                             type: string
                           kind:
                             type: string
                           readOnly:
+                            default: false
                             type: boolean
                         required:
                           - diskName
@@ -1699,6 +1703,13 @@ spec:
                         required:
                           - path
                         type: object
+                      image:
+                        properties:
+                          pullPolicy:
+                            type: string
+                          reference:
+                            type: string
+                        type: object
                       iscsi:
                         properties:
                           chapAuthDiscovery:
@@ -1712,6 +1723,7 @@ spec:
                           iqn:
                             type: string
                           iscsiInterface:
+                            default: default
                             type: string
                           lun:
                             format: int32
@@ -1960,6 +1972,7 @@ spec:
                           image:
                             type: string
                           keyring:
+                            default: /etc/ceph/keyring
                             type: string
                           monitors:
                             items:
@@ -1967,6 +1980,7 @@ spec:
                             type: array
                             x-kubernetes-list-type: atomic
                           pool:
+                            default: rbd
                             type: string
                           readOnly:
                             type: boolean
@@ -1978,6 +1992,7 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           user:
+                            default: admin
                             type: string
                         required:
                           - image
@@ -1986,6 +2001,7 @@ spec:
                       scaleIO:
                         properties:
                           fsType:
+                            default: xfs
                             type: string
                           gateway:
                             type: string
@@ -2003,6 +2019,7 @@ spec:
                           sslEnabled:
                             type: boolean
                           storageMode:
+                            default: ThinProvisioned
                             type: string
                           storagePool:
                             type: string
@@ -2964,6 +2981,8 @@ spec:
                                   properties:
                                     name:
                                       type: string
+                                    request:
+                                      type: string
                                   required:
                                     - name
                                   type: object
@@ -3264,10 +3283,12 @@ spec:
                               diskURI:
                                 type: string
                               fsType:
+                                default: ext4
                                 type: string
                               kind:
                                 type: string
                               readOnly:
+                                default: false
                                 type: boolean
                             required:
                               - diskName
@@ -3627,6 +3648,13 @@ spec:
                             required:
                               - path
                             type: object
+                          image:
+                            properties:
+                              pullPolicy:
+                                type: string
+                              reference:
+                                type: string
+                            type: object
                           iscsi:
                             properties:
                               chapAuthDiscovery:
@@ -3640,6 +3668,7 @@ spec:
                               iqn:
                                 type: string
                               iscsiInterface:
+                                default: default
                                 type: string
                               lun:
                                 format: int32
@@ -3888,6 +3917,7 @@ spec:
                               image:
                                 type: string
                               keyring:
+                                default: /etc/ceph/keyring
                                 type: string
                               monitors:
                                 items:
@@ -3895,6 +3925,7 @@ spec:
                                 type: array
                                 x-kubernetes-list-type: atomic
                               pool:
+                                default: rbd
                                 type: string
                               readOnly:
                                 type: boolean
@@ -3906,6 +3937,7 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               user:
+                                default: admin
                                 type: string
                             required:
                               - image
@@ -3914,6 +3946,7 @@ spec:
                           scaleIO:
                             properties:
                               fsType:
+                                default: xfs
                                 type: string
                               gateway:
                                 type: string
@@ -3931,6 +3964,7 @@ spec:
                               sslEnabled:
                                 type: boolean
                               storageMode:
+                                default: ThinProvisioned
                                 type: string
                               storagePool:
                                 type: string


### PR DESCRIPTION
This reverts commit 6321fb23fd2efc698534bee5366cfddb49bce7d1.

#### Motivation

#### Modifications

#### Result


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
