### PR TITLE
fix prefetch-input (rhoai-2.19)

### DIFF
--- a/.tekton/odh-modelmesh-serving-controller-v2-19-push.yaml
+++ b/.tekton/odh-modelmesh-serving-controller-v2-19-push.yaml
@@ -41,7 +41,7 @@ spec:
     value: true
   - name: prefetch-input
     value: |
-      [{"type": "gomod"}]
+      [{"type": "gomod"}, {"type": "rpm"}]
   - name: build-source-image
     value: true
   - name: build-image-index


### PR DESCRIPTION
#### Motivation
part of https://issues.redhat.com/browse/RHOAIENG-29072

partially revert https://github.com/red-hat-data-services/modelmesh-serving/commit/e7530b38701054e492c30604bfc12a8a3536bbe7

#### Modifications

#### Result


#### PR checklist

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Unit tests pass locally
- [ ] FVT tests pass locally
- [ ] If the PR adds a new container image or updates the tag of an existing image (not build within cpaas), is the corresponding change made in live-builder and cpaas-midstream to add/update the image tag in the operator CSV? Link the PRs if applicable

Checklist items below are applicable for development targeted to both fast and stable branches/tags
- [ ] Tested modelmesh serving deployment with odh-manifests and ran odh-manifests-e2e tests locally 
