### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for odh-modelmesh-serving-controller-v2-22

### DIFF
--- a/Dockerfile.konflux
+++ b/Dockerfile.konflux
@@ -40,7 +40,8 @@ ARG IMAGE_VERSION
 ARG COMMIT_SHA
 
 LABEL com.redhat.component="odh-modelmesh-serving-controller-container" \
-      name="managed-open-data-hub/odh-modelmesh-serving-controller-rhel8" \
+      name="rhoai/odh-modelmesh-serving-controller-rhel9" \
+      cpe="cpe:/a:redhat:openshift_ai:2.22::el9" \
       description="Manages lifecycle of ModelMesh Serving Custom Resources and associated Kubernetes resources" \
       summary="odh-modelmesh-serving-controller" \
       maintainer="['managed-open-data-hub@redhat.com']" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
